### PR TITLE
Add media serving fallback for production

### DIFF
--- a/sql_ai_project/urls.py
+++ b/sql_ai_project/urls.py
@@ -15,11 +15,23 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from django.conf import settings
 from django.conf.urls.static import static
+from django.views.static import serve
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('chat_app.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# In production DEBUG is typically False which prevents the helper above from
+# adding the development media-serving patterns.  The application currently
+# generates chart images at runtime and stores them under MEDIA_ROOT, so expose
+# a lightweight fallback using Django's static file view when DEBUG is False.
+if not settings.DEBUG:
+    urlpatterns += [
+        re_path(r'^media/(?P<path>.*)$', serve, {
+            'document_root': settings.MEDIA_ROOT,
+        }),
+    ]


### PR DESCRIPTION
## Summary
- import Django's `serve` view and `re_path` helper for the URL configuration
- add a DEBUG-aware fallback route so media files remain accessible in production

## Testing
- `python manage.py check` *(fails: missing OPENAI_API_KEY in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e30d892b1483338a12a56724dc20bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Media files are now served directly by the application in non-debug environments, ensuring consistent access to images and other assets.
- Bug Fixes
  - Resolved issues where media content might not load outside of debug mode.
- Chores
  - Updated routing configuration to enable media delivery in production-like settings, improving reliability for end users accessing uploaded assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->