### PR TITLE
Make suggested chat prompts fill the input automatically

### DIFF
--- a/chat_app/static/chat_app/script.js
+++ b/chat_app/static/chat_app/script.js
@@ -451,7 +451,27 @@ document.addEventListener('DOMContentLoaded', () => {
     if (userInput) {
         userInput.addEventListener('keypress', handleKeyPress);
     }
-    
+
+    const exampleQueries = document.querySelectorAll('.example-query');
+    if (exampleQueries.length && userInput) {
+        exampleQueries.forEach(example => {
+            const applyPrompt = () => {
+                const promptText = example.dataset.prompt || example.textContent.trim();
+                if (!promptText) return;
+                userInput.value = promptText;
+                userInput.focus();
+            };
+
+            example.addEventListener('click', applyPrompt);
+            example.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    applyPrompt();
+                }
+            });
+        });
+    }
+
     // Make askAgentUrl available to the script if set by Django template
     if (typeof window.ASK_AGENT_URL_GLOBAL !== 'undefined') {
         askAgentUrl = window.ASK_AGENT_URL_GLOBAL;

--- a/chat_app/static/chat_app/style.css
+++ b/chat_app/static/chat_app/style.css
@@ -442,6 +442,12 @@ header::before {
     transform: translateX(5px);
 }
 
+.example-query:focus {
+    outline: none;
+    background: rgba(255, 140, 0, 0.18);
+    box-shadow: var(--shadow-outline);
+}
+
 .example-query i {
     color: var(--primary-orange);
     font-size: var(--font-size-lg);

--- a/chat_app/templates/chat_app/index.html
+++ b/chat_app/templates/chat_app/index.html
@@ -39,19 +39,19 @@
                     <div class="message-text">
                         Welcome to FloPro SQL Agent! I'm your intelligent data assistant, ready to help you analyze your data with powerful SQL queries and stunning visualizations.
                         <div class="example-queries">
-                            <div class="example-query">
+                            <div class="example-query" role="button" tabindex="0" data-prompt="What are the top 5 products by revenue?">
                                 <i class="fas fa-chart-bar"></i>
                                 <span>What are the top 5 products by revenue?</span>
                             </div>
-                            <div class="example-query">
+                            <div class="example-query" role="button" tabindex="0" data-prompt="Show me monthly sales trends for 1998">
                                 <i class="fas fa-chart-line"></i>
                                 <span>Show me monthly sales trends for 1998</span>
                             </div>
-                            <div class="example-query">
+                            <div class="example-query" role="button" tabindex="0" data-prompt="Provide a bar chart showing total revenue year over year">
                                 <i class="fas fa-chart-column"></i>
                                 <span>Provide a bar chart showing total revenue year over year</span>
                             </div>
-                            <div class="example-query">
+                            <div class="example-query" role="button" tabindex="0" data-prompt="Which customers placed the most orders?">
                                 <i class="fas fa-users"></i>
                                 <span>Which customers placed the most orders?</span>
                             </div>


### PR DESCRIPTION
## Summary
- add accessibility attributes to the landing page example query suggestions
- style focused suggestions for clarity
- populate the chat input when a suggestion is clicked or activated from the keyboard

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: requires OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68e4988f43e883338287b752193e5625