### PR TITLE
Add auto-run SQL toggle and handling

### DIFF
--- a/chat_app/static/chat_app/style.css
+++ b/chat_app/static/chat_app/style.css
@@ -472,6 +472,98 @@ header::before {
     border: 2px solid #ff6b6b;
 }
 
+/* Preferences Toggle */
+.preferences-panel {
+    margin-top: var(--spacing-4);
+    margin-bottom: var(--spacing-2);
+    padding: var(--spacing-4);
+    background: rgba(45, 45, 45, 0.6);
+    border: 1px solid rgba(255, 140, 0, 0.2);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+}
+
+.toggle-wrapper {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-4);
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 56px;
+    height: 32px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 140, 0, 0.25);
+    transition: var(--transition-normal);
+    border-radius: var(--radius-full);
+}
+
+.slider::before {
+    position: absolute;
+    content: "";
+    height: 24px;
+    width: 24px;
+    left: 4px;
+    top: 4px;
+    background: var(--white);
+    border-radius: 50%;
+    transition: var(--transition-normal);
+    box-shadow: var(--shadow-sm);
+}
+
+.switch input:checked + .slider {
+    background: var(--accent-gradient);
+}
+
+.switch input:checked + .slider::before {
+    transform: translateX(24px);
+    background: var(--primary-orange);
+}
+
+.switch:focus-within .slider {
+    box-shadow: var(--shadow-outline);
+}
+
+.toggle-copy {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+}
+
+.toggle-title {
+    font-weight: 600;
+    font-size: var(--font-size-md);
+    color: var(--white);
+}
+
+.toggle-description {
+    font-size: var(--font-size-sm);
+    color: var(--gray-light);
+}
+
+.toggle-status {
+    font-size: var(--font-size-xs);
+    color: var(--primary-orange-light);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
 /* Input Area */
 .input-area {
     display: flex;

--- a/chat_app/templates/chat_app/index.html
+++ b/chat_app/templates/chat_app/index.html
@@ -61,7 +61,21 @@
             </div>
             <!-- Chat messages will appear here -->
         </div>
-        
+
+        <div class="preferences-panel" role="group" aria-labelledby="autoExecuteTitle">
+            <div class="toggle-wrapper">
+                <label class="switch" aria-label="Toggle automatic SQL execution">
+                    <input type="checkbox" id="autoExecuteToggle" aria-describedby="autoExecuteDescription">
+                    <span class="slider"></span>
+                </label>
+                <div class="toggle-copy">
+                    <span id="autoExecuteTitle" class="toggle-title">Auto-run SQL</span>
+                    <span id="autoExecuteDescription" class="toggle-description">Skip manual approval and run generated SQL automatically.</span>
+                    <span id="autoExecuteStatusText" class="toggle-status"></span>
+                </div>
+            </div>
+        </div>
+
         <div class="input-area">
             <div class="input-wrapper">
                 <i class="fas fa-comment-dots input-icon"></i>


### PR DESCRIPTION
## Summary
- add an "Auto-run SQL" toggle to the chat UI with styling and saved preference
- send the preference with chat requests and reuse it when approving SQL
- centralize SQL execution/resume logic so the backend can honor auto-run mode

## Testing
- python manage.py check *(fails: OPENAI_API_KEY environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a17534808333b81d5ffaff1bb1d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a Preferences panel with a toggle to automatically execute SQL without manual approval.
  * Preference is saved in your browser and shown via a live status indicator.
* Style
  * New, accessible styling for the Preferences panel and toggle, with hover/focus states and consistent theming.
* Bug Fixes
  * Improved session state cleanup and initialization to reduce stale approval prompts and ensure smoother chat resumes and page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->